### PR TITLE
Make it work with Phlex V2's new context API

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ gemspec
 
 gem 'capybara'
 gem 'haml'
+gem 'phlex', github: 'phlex-ruby/phlex'
 gem 'puma'
 gem 'rack-test'
 gem 'rake'


### PR DESCRIPTION
Hi! 👋 

Phlex 2 changes the way the view context is passed into Phlex components.

Before:

```ruby
some_component.call(view_context:)
```

After:

```ruby
some_component.call(context: {...})
```

Frameworks are free to pass their "view contexts" as a key in the `context` hash with whatever name they want.

This PR makes the code support both v1 and v2. For the latter with no user-facing changes.

## Notes

I'm just pointing the Gemfile to Phlex's `main` branch on Gitub, so that it specs run against the latest version.
A test dependency matrix might be a good idea.